### PR TITLE
Include an existing MD5 if it exists

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,10 @@ Request message structure:
 	    "metadata": "DISK-SHARE-EVENTS",
 	    "video": "TAPE-SHARE-EVENTS",
 	    "archive": "TAPE-SHARE-EVENTS"
+	},
+	"checksums": {
+    	"4746q1wv0v_0001_tif.tif": "d41d8cd98f00b204e9800998ecf8427e",
+    	"4746q1wv0v_0002_tif.tif": "d41d8cd98f00b204e9800998ecf8427e"
 	}
 }
 ```

--- a/utils/file-utils.js
+++ b/utils/file-utils.js
@@ -36,7 +36,7 @@ var crypto = require ('crypto');
 		while ( nr = fs.readSync (fd, buffer, 0, buffer.length) ) {
 			hash.update (buffer.slice (0, nr));
 		}
-		fs.close(fd);
+		fs.closeSync(fd);
 		return hash.digest ('hex');
 	}
 

--- a/utils/generator.js
+++ b/utils/generator.js
@@ -59,11 +59,9 @@ var Logger = require('./logger').Logger;
 		addObjects (this.xml, datanode, data);
 	}
 
-	Generator.prototype.addFilesSection = function addFilesSection (files) {
+	Generator.prototype.addFilesSection = function addFilesSection (files, checksums) {
 		var group = addNode (this.xml, this.root, ['mets:fileSec', 'mets:fileGrp']);
-
 		var id = this.config.pid;
-
 		group.attr ('ID', 'id_' + id);
 		group.attr ('ADMID', 'METADATA-ENSEMBLE');
 		group.attr ('USE', 'DISK-SHARE-EVENTS');
@@ -101,7 +99,12 @@ var Logger = require('./logger').Logger;
 			}
 
 			filenode.attr ('MIMETYPE', mimetype);
-			filenode.attr ('CHECKSUM', calcMD5 (this.config.directory + '/' + file));
+			if (checksums[file] === undefined) {
+				filenode.attr ('CHECKSUM', calcMD5(this.config.directory + '/' + file));
+			}
+			else {
+				filenode.attr ('CHECKSUM', checksums[file]);
+			}
 			filenode.attr ('CHECKSUMTYPE', 'MD5');
 			// MAKE SURE TIFS ARE SET TO fileUse.essence, others to fileUse.other
 			filenode.attr ('USE', this.config.fileUse[simpletype]);
@@ -183,7 +186,7 @@ var Logger = require('./logger').Logger;
 
 		this.addAgents (this.config.agents);
 		this.addMetaSection ('METADATA-ENSEMBLE', this.config.metadata.digital_object);
-		this.addFilesSection (files);
+		this.addFilesSection (files, this.config.checksums);
 		this.addStructureMap ();
 
 		if ( this.params.writeToDisk ) {

--- a/utils/generator.js
+++ b/utils/generator.js
@@ -60,7 +60,7 @@ var Logger = require('./logger').Logger;
 	}
 
 	Generator.prototype.addFilesSection = function addFilesSection (files, checksums) {
-		var group = addNode (this.xml, this.root, ['mets:fileSec', 'mets:fileGrp']);
+		var group = addNode(this.xml, this.root, ['mets:fileSec', 'mets:fileGrp']);
 		var id = this.config.pid;
 		group.attr ('ID', 'id_' + id);
 		group.attr ('ADMID', 'METADATA-ENSEMBLE');
@@ -99,11 +99,11 @@ var Logger = require('./logger').Logger;
 			}
 
 			filenode.attr ('MIMETYPE', mimetype);
-			if (checksums[file] === undefined) {
-				filenode.attr ('CHECKSUM', calcMD5(this.config.directory + '/' + file));
+			if (checksums[path.basename(file)] === undefined) {
+				filenode.attr('CHECKSUM', calcMD5(this.config.directory + '/' + file));
 			}
 			else {
-				filenode.attr ('CHECKSUM', checksums[file]);
+				filenode.attr('CHECKSUM', checksums[path.basename(file)]);
 			}
 			filenode.attr ('CHECKSUMTYPE', 'MD5');
 			// MAKE SURE TIFS ARE SET TO fileUse.essence, others to fileUse.other


### PR DESCRIPTION
Send along a list of MD5's (as shown in the example in readme.md) when requesting the creation of a METS file. These MD5's will be used instead of ones being generated on the fly.